### PR TITLE
fix: Add sequential thinking triggers (BUG-029 & BUG-034)

### DIFF
--- a/src/behaviors/prb-auto-trigger.md
+++ b/src/behaviors/prb-auto-trigger.md
@@ -49,14 +49,15 @@ Auto-breakdown PRBs if complexity > 15 points into multiple PRBs ≤15 points ea
 2. **Gather** complete context (MANDATORY)
 3. **Search** memory/[topic]/ and best-practices/ (MANDATORY)
 4. **Score** complexity
-5. **Auto-breakdown** if complexity > 15 points
-6. **Load Template** from src/prb-templates/ 
-7. **Load Configuration** at generation time
-8. **Resolve ALL Placeholders** with actual config values
-9. **Embed Complete Context** - all config in PRB
-10. **Validate NO Placeholders** - ZERO unresolved values
-11. **Generate** compliant name and create PRB
-12. **Execute** via subagent
+5. **Sequential thinking** if complexity > 5 points, use mcp__sequential-thinking__sequentialthinking for structured PRB design
+6. **Auto-breakdown** if complexity > 15 points
+7. **Load Template** from src/prb-templates/ 
+8. **Load Configuration** at generation time
+9. **Resolve ALL Placeholders** with actual config values
+10. **Embed Complete Context** - all config in PRB
+11. **Validate NO Placeholders** - ZERO unresolved values
+12. **Generate** compliant name and create PRB
+13. **Execute** via subagent
 
 ## Context Requirements
 

--- a/src/behaviors/story-breakdown.md
+++ b/src/behaviors/story-breakdown.md
@@ -48,10 +48,11 @@
 
 ### Auto-Breakdown Process
 1. **Analyze complexity:** Calculate total story complexity points
-2. **AUTO-BREAKDOWN:** If >15 points, use logical decomposition
-3. **Generate sub-PRBs:** Each ≤15 points with specific focus
-4. **Sequential numbering:** Under same parent with dependencies documented
-5. **FAIL-SAFE:** If auto-breakdown fails, BLOCK with manual breakdown request
+2. **Sequential thinking:** If complexity >10 points, use mcp__sequential-thinking__sequentialthinking for structured analysis
+3. **AUTO-BREAKDOWN:** If >15 points, use logical decomposition
+4. **Generate sub-PRBs:** Each ≤15 points with specific focus
+5. **Sequential numbering:** Under same parent with dependencies documented
+6. **FAIL-SAFE:** If auto-breakdown fails, BLOCK with manual breakdown request
 
 ## Story Selection Criteria
 


### PR DESCRIPTION
## Summary
Adds minimal sequential thinking triggers to fix both BUG-029 and BUG-034 with just 2 lines of code.

## Changes
- Added trigger in `story-breakdown.md` for complexity >10
- Added trigger in `prb-auto-trigger.md` for complexity >5
- Uses existing `mcp__sequential-thinking__sequentialthinking` tool
- NO new behavioral patterns - architectural precision

## Fixes
- Resolves BUG-029: Sequential thinking absence in main scope
- Resolves BUG-034: Sequential thinking not being used despite v7.3.13

## Architecture Decision
@AI-Architect identified optimal integration points for minimal change and maximum impact.