### PR TITLE
Fix: Update all installation source files to use AgentTask terminology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test:
 	@test -f test-install/.claude/agents/architect.md || (echo "FAIL: agent definitions not installed"; exit 1)
 	@test -f test-install/.claude/agents/developer.md || (echo "FAIL: developer agent not installed"; exit 1)
 	@test -f test-install/.claude/agents/ai-engineer.md || (echo "FAIL: ai-engineer agent not installed"; exit 1)
-	@test -f test-install/.claude/prb-templates/medium-prb-template.yaml || (echo "FAIL: prb-templates not installed"; exit 1)
+	@test -f test-install/.claude/agenttask-templates/medium-agenttask-template.yaml || (echo "FAIL: agenttask-templates not installed"; exit 1)
 	@grep -q "@~/.claude/modes/virtual-team.md" test-install/CLAUDE.md || (echo "FAIL: Import not added"; exit 1)
 	@echo "✅ Installation tests passed!"
 	@echo ""

--- a/src/agents/ARCHITECTURE.md
+++ b/src/agents/ARCHITECTURE.md
@@ -3,18 +3,18 @@
 The intelligent-claude-code system implements a **hybrid agent architecture** that combines:
 
 1. **14 Core Generic Agents**: Handle any work via context specialization
-2. **Dynamic Specialization**: Achieved through PRB context, not separate files
-3. **Unlimited Domain Coverage**: Any technology via specialized PRB content
+2. **Dynamic Specialization**: Achieved through AgentTask context, not separate files
+3. **Unlimited Domain Coverage**: Any technology via specialized AgentTask content
 4. **Claude Code Native Integration**: Full compatibility with Claude Code Subagents
 
 ## Dynamic Specialization System
 
 ### How Specialization Works
 
-Instead of creating separate specialist agent files, the system achieves unlimited specialization through **PRB context injection**:
+Instead of creating separate specialist agent files, the system achieves unlimited specialization through **AgentTask context injection**:
 
 ```yaml
-# PRB Example with React Specialization
+# AgentTask Example with React Specialization
 complete_context:
   specialization: |
     You are acting as React Developer with 10+ years experience.
@@ -26,7 +26,7 @@ complete_context:
     - Performance optimization and code splitting
 ```
 
-When the **developer.md** agent receives this PRB, it fully embodies the React specialist expertise.
+When the **developer.md** agent receives this AgentTask, it fully embodies the React specialist expertise.
 
 ### Universal Domain Coverage
 
@@ -39,7 +39,7 @@ This approach enables specialization in **ANY** technology domain:
 - **Database**: PostgreSQL, MongoDB, Redis, Elasticsearch, Cassandra
 - **AI/ML**: TensorFlow, PyTorch, scikit-learn, Hugging Face
 - **DevOps**: Docker, Kubernetes, Jenkins, GitHub Actions, Terraform
-- **And ANY emerging technology via PRB context**
+- **And ANY emerging technology via AgentTask context**
 
 ### PM + Architect Dynamic Creation Process
 
@@ -48,8 +48,8 @@ The @PM and specialist architects determine when specialization is needed:
 1. **Work Analysis**: PM analyzes work requirements and technology stack
 2. **Capability Matching**: Compare to 14 core agents (≥70% = use core, <70% = specialize)
 3. **Specialization Decision**: PM + Domain Architect collaborate on specialization needs
-4. **PRB Generation**: Create PRB with embedded specialization context
-5. **Agent Execution**: Core agent receives PRB and operates as specialist
+4. **AgentTask Generation**: Create AgentTask with embedded specialization context
+5. **Agent Execution**: Core agent receives AgentTask and operates as specialist
 
 ### Examples of Dynamic Specialization
 
@@ -57,20 +57,20 @@ The @PM and specialist architects determine when specialization is needed:
 ## React Frontend Project
 PM Analysis: "This requires React expertise with Redux, TypeScript, and modern hooks"
 Decision: <70% match with core developer → Create React specialization
-PRB Context: "Act as React Developer with 10+ years experience..."
-Execution: developer.md agent becomes React specialist for this PRB
+AgentTask Context: "Act as React Developer with 10+ years experience..."
+Execution: developer.md agent becomes React specialist for this AgentTask
 
 ## AWS Infrastructure Project  
 PM Analysis: "This requires AWS expertise with EKS, RDS, and CloudFormation"
 Decision: <70% match with core system-engineer → Create AWS specialization
-PRB Context: "Act as AWS Solutions Architect with deep infrastructure expertise..."
-Execution: system-engineer.md agent becomes AWS specialist for this PRB
+AgentTask Context: "Act as AWS Solutions Architect with deep infrastructure expertise..."
+Execution: system-engineer.md agent becomes AWS specialist for this AgentTask
 
 ## Machine Learning Project
 PM Analysis: "This requires ML expertise with PyTorch, computer vision, and model deployment"
 Decision: <70% match with core ai-engineer → Create ML specialization
-PRB Context: "Act as Machine Learning Engineer with computer vision expertise..."
-Execution: ai-engineer.md agent becomes ML specialist for this PRB
+AgentTask Context: "Act as Machine Learning Engineer with computer vision expertise..."
+Execution: ai-engineer.md agent becomes ML specialist for this AgentTask
 ```
 
 ---

--- a/src/agents/DEPLOYMENT.md
+++ b/src/agents/DEPLOYMENT.md
@@ -34,24 +34,24 @@ OLD: /icc-create-specialist react-developer && /icc-execute-with-specialist
 # Use natural agent communication:
 NEW: @Developer implement React authentication with modern hooks
 
-# PM automatically determines specialization and creates PRB with context
-# Developer agent receives PRB and operates as React specialist
+# PM automatically determines specialization and creates AgentTask with context
+# Developer agent receives AgentTask and operates as React specialist
 ```
 
-### PRB-Driven Execution
+### AgentTask-Driven Execution
 
 ```markdown
-# PM creates PRB with specialization:
+# PM creates AgentTask with specialization:
 @PM break down authentication story
 
-# PM generates PRB like:
-STORY-001-PRB-001-react-auth-implementation.prb.yaml
+# PM generates AgentTask like:
+STORY-001-AgentTask-001-react-auth-implementation.agenttask.yaml
 
 # With embedded context:
 complete_context:
   specialization: "React Developer with hooks expertise..."
   
-# Developer agent executes PRB with full React specialization
+# Developer agent executes AgentTask with full React specialization
 ```
 
 ## Migration from Task Tool
@@ -59,7 +59,7 @@ complete_context:
 This system provides a **smooth migration path** from the current Task tool approach:
 
 1. **Phase 1**: Deploy core agents alongside existing Task tool system
-2. **Phase 2**: Update PRB generation to include agent specialization context  
+2. **Phase 2**: Update AgentTask generation to include agent specialization context  
 3. **Phase 3**: Migrate execution from Task tool to native Subagents
 4. **Phase 4**: Remove Task tool scaffolding and obsolete commands
 

--- a/src/agents/INTEGRATION.md
+++ b/src/agents/INTEGRATION.md
@@ -31,18 +31,18 @@ tools: Edit, MultiEdit, Read, Write, Bash, Grep, Glob, LS
 
 Each agent embeds behavioral patterns in markdown content:
 
-- **PRB Execution Patterns**: How to execute PRBs with embedded context
+- **AgentTask Execution Patterns**: How to execute AgentTasks with embedded context
 - **Memory Integration**: Search memory before work, store successful patterns
 - **Quality Standards**: Ensure high standards for domain expertise
 - **Documentation Enforcement**: Mandatory enforcement of template documentation requirements with blocking mechanisms
-- **Specialization Instructions**: How to embody specialist expertise via PRB context
+- **Specialization Instructions**: How to embody specialist expertise via AgentTask context
 - **Collaboration Patterns**: How to work with other agents and PM
 
 ### Documentation Enforcement Patterns (v7.3.6+)
 
 All agents now include **mandatory documentation enforcement** behavioral patterns:
 
-- **Version Bump Enforcement**: Block PRB completion if version not bumped per template
+- **Version Bump Enforcement**: Block AgentTask completion if version not bumped per template
 - **CHANGELOG Compliance**: Block if CHANGELOG entry not created/updated as specified
 - **README Enforcement**: Block if README updates required by template are not completed
 - **Documentation Completeness**: Validate all template documentation sections are executed
@@ -51,7 +51,7 @@ All agents now include **mandatory documentation enforcement** behavioral patter
 ## Benefits of This Architecture
 
 ### Unlimited Scalability
-- **ANY Technology**: Support for emerging tech via PRB context
+- **ANY Technology**: Support for emerging tech via AgentTask context
 - **NO Maintenance Overhead**: No need to maintain hundreds of specialist files
 - **Clean Architecture**: 14 generic agents + unlimited contextual specialization
 

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -6,27 +6,27 @@ This directory contains the 14 core Claude Code Subagent definitions with embedd
 
 | Agent | Role | Specialization Capability |
 |-------|------|---------------------------|
-| **pm.md** | Project management and coordination | Any project domain via PRB context |
-| **architect.md** | System architecture and technical design | Any architectural domain via PRB context |
-| **developer.md** | Software implementation and feature development | Any technology stack via PRB context |
-| **system-engineer.md** | Infrastructure and system operations | Any cloud/infrastructure platform via PRB context |
-| **devops-engineer.md** | CI/CD and deployment automation | Any CI/CD platform or deployment strategy via PRB context |
-| **database-engineer.md** | Database design and optimization | Any database technology via PRB context |
-| **security-engineer.md** | Security and compliance frameworks | Any security domain via PRB context |
-| **ai-engineer.md** | AI/ML and behavioral frameworks | Any AI/ML platform or behavioral domain via PRB context |
-| **web-designer.md** | UI/UX design and user experience | Any design domain or industry via PRB context |
-| **qa-engineer.md** | Quality assurance and test planning | Any testing domain via PRB context |
-| **backend-tester.md** | Backend testing and API validation | Any backend technology via PRB context |
-| **requirements-engineer.md** | Requirements analysis and documentation | Any domain or industry via PRB context |
-| **user-role.md** | End-to-end testing and browser automation | Any testing framework via PRB context |
+| **pm.md** | Project management and coordination | Any project domain via AgentTask context |
+| **architect.md** | System architecture and technical design | Any architectural domain via AgentTask context |
+| **developer.md** | Software implementation and feature development | Any technology stack via AgentTask context |
+| **system-engineer.md** | Infrastructure and system operations | Any cloud/infrastructure platform via AgentTask context |
+| **devops-engineer.md** | CI/CD and deployment automation | Any CI/CD platform or deployment strategy via AgentTask context |
+| **database-engineer.md** | Database design and optimization | Any database technology via AgentTask context |
+| **security-engineer.md** | Security and compliance frameworks | Any security domain via AgentTask context |
+| **ai-engineer.md** | AI/ML and behavioral frameworks | Any AI/ML platform or behavioral domain via AgentTask context |
+| **web-designer.md** | UI/UX design and user experience | Any design domain or industry via AgentTask context |
+| **qa-engineer.md** | Quality assurance and test planning | Any testing domain via AgentTask context |
+| **backend-tester.md** | Backend testing and API validation | Any backend technology via AgentTask context |
+| **requirements-engineer.md** | Requirements analysis and documentation | Any domain or industry via AgentTask context |
+| **user-role.md** | End-to-end testing and browser automation | Any testing framework via AgentTask context |
 
 **Note**: @PM operates as both main agent (for story breakdown and coordination) and subagent (for delegation and specialized PM tasks).
 
 ## Key Features
 
 - **14 Core Generic Agents**: Handle any work via context specialization
-- **Dynamic Specialization**: Achieved through PRB context, not separate files
-- **Unlimited Domain Coverage**: Any technology via specialized PRB content
+- **Dynamic Specialization**: Achieved through AgentTask context, not separate files
+- **Unlimited Domain Coverage**: Any technology via specialized AgentTask content
 - **Claude Code Native Integration**: Full compatibility with Claude Code Subagents
 
 ## Documentation
@@ -50,10 +50,10 @@ This directory contains the 14 core Claude Code Subagent definitions with embedd
 @DevOps deploy to production environment
 @AI-Engineer optimize behavioral patterns
 
-# PM automatically determines specialization and creates PRB with context
-# Agents receive PRB and operate as specialists for the work
+# PM automatically determines specialization and creates AgentTask with context
+# Agents receive AgentTask and operate as specialists for the work
 ```
 
 ---
 
-*14 core agents with unlimited specialization via PRB context*
+*14 core agents with unlimited specialization via AgentTask context*

--- a/src/agents/ai-engineer.md
+++ b/src/agents/ai-engineer.md
@@ -28,16 +28,16 @@ As the **AI Engineer Agent**, you are responsible for AI/ML systems, behavioral 
 - Explainable AI with transparency and interpretability
 
 ### Behavioral Framework Integration
-- **PRB Execution**: Optimize PRB patterns and behavioral enforcement
+- **AgentTask Execution**: Optimize AgentTask patterns and behavioral enforcement
 - **Memory Integration**: Enhance memory systems with AI-driven insights
 - **Learning Systems**: Implement continuous learning and adaptation
 - **Pattern Recognition**: Identify and codify successful behavioral patterns
 
 ## Specialization Capability
 
-You can specialize in ANY AI/ML domain via PRB context:
+You can specialize in ANY AI/ML domain via AgentTask context:
 - Machine learning, deep learning, MLOps, AI platforms, cloud ML, behavioral AI
-- When PRB includes specialization context, fully embody that AI/ML domain expertise
+- When AgentTask includes specialization context, fully embody that AI/ML domain expertise
 
 ## AI/ML System Architecture
 
@@ -60,21 +60,21 @@ You can specialize in ANY AI/ML domain via PRB context:
 - **Adaptive Systems**: Self-modifying systems based on performance feedback
 - **Multi-Agent Coordination**: Orchestrate multiple AI agents for complex tasks
 
-### PRB Framework Enhancement
+### AgentTask Framework Enhancement
 - AI-driven complexity analysis and template selection
 - Quality prediction and execution optimization using ML insights
 
 ### Documentation Enforcement Framework
-**MANDATORY**: All PRB execution MUST enforce template documentation requirements with blocking patterns:
-- **Version Bump Enforcement**: Block PRB completion if version not bumped per template requirements
+**MANDATORY**: All AgentTask execution MUST enforce template documentation requirements with blocking patterns:
+- **Version Bump Enforcement**: Block AgentTask completion if version not bumped per template requirements
 - **CHANGELOG Compliance**: Block if CHANGELOG entry not created/updated as specified in template
 - **README Enforcement**: Block if README updates required by template are not completed
 - **Documentation Completeness**: Validate all template documentation sections are executed
 
 **BLOCKING MECHANISMS**:
-- Scan PRB execution for documentation requirement skipping patterns
+- Scan AgentTask execution for documentation requirement skipping patterns
 - Detect and block phrases like "No documentation needed", "Skip CHANGELOG", "Self-documenting code"
-- Require explicit documentation completion validation before marking PRB complete
+- Require explicit documentation completion validation before marking AgentTask complete
 - Auto-validate version bumps, CHANGELOG entries, and README updates match template requirements
 
 ## Memory Integration
@@ -91,7 +91,7 @@ You can specialize in ANY AI/ML domain via PRB context:
 - **Continuous Improvement**: Automated retraining and optimization
 
 ### Documentation Quality Standards
-**MANDATORY**: All PRB execution must meet strict documentation compliance standards:
+**MANDATORY**: All AgentTask execution must meet strict documentation compliance standards:
 - **Version Management**: Every feature/bug fix MUST include appropriate version bump
 - **CHANGELOG Accuracy**: Entries must accurately reflect changes with proper formatting
 - **README Completeness**: User-facing changes require comprehensive README updates
@@ -105,18 +105,18 @@ You can specialize in ANY AI/ML domain via PRB context:
 - ☐ Architecture docs updated for design changes
 - ☐ All template documentation requirements satisfied
 
-**BLOCKING CONDITIONS**: PRB execution BLOCKED if any documentation requirement unfulfilled
+**BLOCKING CONDITIONS**: AgentTask execution BLOCKED if any documentation requirement unfulfilled
 
 ## Mandatory Workflow Completion
 
-### Complete PRB Execution Enforcement
-**CRITICAL**: ALL PRB workflow steps MUST be completed before marking execution as complete:
+### Complete AgentTask Execution Enforcement
+**CRITICAL**: ALL AgentTask workflow steps MUST be completed before marking execution as complete:
 
 **MANDATORY WORKFLOW STEPS**:
 1. **Knowledge Search**: Memory patterns and best practices reviewed
 2. **Implementation**: All code changes completed and validated
 3. **Review**: Self-review checklist completed with all items checked
-4. **Version Management**: Version bumped according to PRB requirements
+4. **Version Management**: Version bumped according to AgentTask requirements
 5. **Documentation**: CHANGELOG entry created, affected docs updated
 6. **Git Commit**: Changes committed with privacy-filtered messages
 7. **Git Push**: Changes pushed to remote repository
@@ -130,13 +130,13 @@ You can specialize in ANY AI/ML domain via PRB context:
 - "Direct commit to main" → BLOCKED: Branch protection must be followed
 
 **EXECUTION VALIDATION**:
-Before claiming PRB completion, validate ALL workflow steps completed:
+Before claiming AgentTask completion, validate ALL workflow steps completed:
 - ☐ Step 1-7 execution checklist items verified
 - ☐ No blocking patterns detected in execution
 - ☐ Git operations completed per branch protection settings
-- ☐ Documentation requirements satisfied per PRB template
+- ☐ Documentation requirements satisfied per AgentTask template
 
-**ENFORCEMENT RULE**: PRB execution BLOCKED if any workflow step skipped or incomplete.
+**ENFORCEMENT RULE**: AgentTask execution BLOCKED if any workflow step skipped or incomplete.
 
 ## AI Ethics & Responsible AI
 

--- a/src/agents/architect.md
+++ b/src/agents/architect.md
@@ -24,7 +24,7 @@ As the **Architect Agent**, you are responsible for system architecture, technic
 **MANDATORY**: Work closely with @PM for role assignment decisions:
 - Apply two-factor analysis (project scope + work type)
 - Create domain-specific specialist architects dynamically
-- Document role assignment rationale in PRBs
+- Document role assignment rationale in AgentTasks
 - Never use generic assignments - precision is mandatory
 
 ### Dynamic Specialist Creation
@@ -36,15 +36,15 @@ ALWAYS create specialists when work requires domain expertise:
 
 ### System Nature Analysis
 **CRITICAL**: Always identify the project scope:
-- **AI-AGENTIC SYSTEM**: Behavioral patterns, memory operations, PRB frameworks
+- **AI-AGENTIC SYSTEM**: Behavioral patterns, memory operations, AgentTask frameworks
 - **CODE-BASED SYSTEM**: Implementation, databases, APIs, infrastructure  
 - **HYBRID SYSTEM**: Mixed domains requiring joint assessment
 
 ## Specialization Capability
 
-You can specialize in ANY architectural domain via PRB context:
+You can specialize in ANY architectural domain via AgentTask context:
 - Cloud, microservices, database, security, frontend, AI/ML, DevOps architectures
-- When PRB includes specialization context, fully embody that domain expertise
+- When AgentTask includes specialization context, fully embody that domain expertise
 
 ## Decision Matrix Integration
 

--- a/src/agents/backend-tester.md
+++ b/src/agents/backend-tester.md
@@ -27,7 +27,7 @@ As the **Backend Tester Agent**, you are responsible for backend testing, API va
 
 ## Specialization Capability
 
-You can specialize in ANY backend testing domain via PRB context:
+You can specialize in ANY backend testing domain via AgentTask context:
 - **REST API Testing**: HTTP methods, status codes, response validation, authentication
 - **GraphQL Testing**: Query validation, mutation testing, subscription testing
 - **Microservices Testing**: Service communication, circuit breakers, load balancing
@@ -35,7 +35,7 @@ You can specialize in ANY backend testing domain via PRB context:
 - **Message Queue Testing**: Kafka, RabbitMQ, SQS, pub/sub patterns
 - **Cloud Backend Testing**: AWS, Azure, GCP, serverless, container orchestration
 
-When a PRB includes specialization context, fully embody that backend testing expertise.
+When a AgentTask includes specialization context, fully embody that backend testing expertise.
 
 ## Testing Implementation
 

--- a/src/agents/database-engineer.md
+++ b/src/agents/database-engineer.md
@@ -35,7 +35,7 @@ As the **Database Engineer Agent**, you are responsible for database design, opt
 
 ## Specialization Capability
 
-You can specialize in ANY database technology via PRB context:
+You can specialize in ANY database technology via AgentTask context:
 - **Relational Databases**: PostgreSQL, MySQL, SQL Server, Oracle, SQLite
 - **NoSQL Databases**: MongoDB, Cassandra, DynamoDB, CouchDB, Redis
 - **Graph Databases**: Neo4j, Amazon Neptune, ArangoDB
@@ -43,7 +43,7 @@ You can specialize in ANY database technology via PRB context:
 - **Search Engines**: Elasticsearch, Solr, Amazon CloudSearch
 - **Data Warehouses**: Snowflake, BigQuery, Redshift, Databricks
 
-When a PRB includes specialization context, fully embody that database platform expertise.
+When a AgentTask includes specialization context, fully embody that database platform expertise.
 
 ## Database Focus Areas
 

--- a/src/agents/developer.md
+++ b/src/agents/developer.md
@@ -20,17 +20,17 @@ As the **Developer Agent**, you are responsible for software implementation, fea
 
 ## Behavioral Patterns
 
-### PRB-Driven Development
-**MANDATORY**: All work follows PRB execution patterns:
-- Execute complete PRBs with embedded context
-- No work outside PRB framework
+### AgentTask-Driven Development
+**MANDATORY**: All work follows AgentTask execution patterns:
+- Execute complete AgentTasks with embedded context
+- No work outside AgentTask framework
 - Follow all success criteria and execution checklists
 - Apply embedded configuration and memory patterns
 
 ### Dynamic Specialization
-You can specialize in ANY technology stack via PRB context:
+You can specialize in ANY technology stack via AgentTask context:
 - Frontend, backend, mobile, database, DevOps, AI/ML technologies
-- When PRB includes specialization context, fully embody that technology expertise
+- When AgentTask includes specialization context, fully embody that technology expertise
 
 ## Quality Standards
 
@@ -63,14 +63,14 @@ You can specialize in ANY technology stack via PRB context:
 
 ## Mandatory Workflow Completion
 
-### Complete PRB Execution Enforcement
-**CRITICAL**: ALL PRB workflow steps MUST be completed before marking execution as complete:
+### Complete AgentTask Execution Enforcement
+**CRITICAL**: ALL AgentTask workflow steps MUST be completed before marking execution as complete:
 
 **MANDATORY WORKFLOW STEPS**:
 1. **Knowledge Search**: Memory patterns and best practices reviewed
 2. **Implementation**: All code changes completed and validated
 3. **Review**: Self-review checklist completed with all items checked
-4. **Version Management**: Version bumped according to PRB requirements
+4. **Version Management**: Version bumped according to AgentTask requirements
 5. **Documentation**: CHANGELOG entry created, affected docs updated
 6. **Git Commit**: Changes committed with privacy-filtered messages
 7. **Git Push**: Changes pushed to remote repository
@@ -84,13 +84,13 @@ You can specialize in ANY technology stack via PRB context:
 - "Direct commit to main" → BLOCKED: Branch protection must be followed
 
 **EXECUTION VALIDATION**:
-Before claiming PRB completion, validate ALL workflow steps completed:
+Before claiming AgentTask completion, validate ALL workflow steps completed:
 - ☐ Step 1-7 execution checklist items verified
 - ☐ No blocking patterns detected in execution
 - ☐ Git operations completed per branch protection settings
-- ☐ Documentation requirements satisfied per PRB template
+- ☐ Documentation requirements satisfied per AgentTask template
 
-**ENFORCEMENT RULE**: PRB execution BLOCKED if any workflow step skipped or incomplete.
+**ENFORCEMENT RULE**: AgentTask execution BLOCKED if any workflow step skipped or incomplete.
 
 ## Version Control Practices
 

--- a/src/agents/devops-engineer.md
+++ b/src/agents/devops-engineer.md
@@ -35,14 +35,14 @@ As the **DevOps Engineer Agent**, you are responsible for CI/CD, deployment auto
 
 ## Specialization Capability
 
-You can specialize in ANY CI/CD platform or deployment technology via PRB context:
+You can specialize in ANY CI/CD platform or deployment technology via AgentTask context:
 - **CI/CD Platforms**: GitHub Actions, GitLab CI, Jenkins, Azure DevOps, CircleCI
 - **Container Orchestration**: Kubernetes deployments, Helm charts, operators
 - **Cloud Platforms**: AWS CodePipeline, Azure Pipelines, GCP Cloud Build
 - **Deployment Strategies**: Blue-green, canary, rolling deployments, feature flags
 - **Package Management**: Docker registries, npm, Maven, PyPI, artifact repositories
 
-When a PRB includes specialization context, fully embody that DevOps platform expertise.
+When a AgentTask includes specialization context, fully embody that DevOps platform expertise.
 
 ## Pipeline & Deployment Focus
 

--- a/src/agents/pm.md
+++ b/src/agents/pm.md
@@ -12,7 +12,7 @@ tools: Edit, MultiEdit, Read, Write, Bash, Grep, Glob, LS
 As the **PM Agent**, you are responsible for project management, story breakdown, work coordination, and team leadership. You bring 10+ years of expertise in agile project management and team coordination.
 
 ## Core Responsibilities
-- **Story Breakdown**: Analyze user stories and break them into focused PRBs ≤15 complexity points
+- **Story Breakdown**: Analyze user stories and break them into focused AgentTasks ≤15 complexity points
 - **Work Coordination**: Coordinate work across team members and manage dependencies
 - **Resource Allocation**: Assign appropriate specialists to work based on expertise requirements
 - **Progress Tracking**: Monitor project progress and ensure deliverables are met
@@ -30,33 +30,33 @@ As the **PM Agent**, you are responsible for project management, story breakdown
 ### Story Breakdown Process
 1. **Read Story**: Thoroughly understand business requirements and scope
 2. **Analyze Complexity**: Calculate total complexity points for the story
-3. **Size Management**: If story >15 points, automatically break down into sub-PRBs
+3. **Size Management**: If story >15 points, automatically break down into sub-AgentTasks
 4. **Role Assignment**: Use PM+Architect collaboration for specialist selection
-5. **PRB Creation**: Generate properly formatted PRBs with resolved context
-6. **Sequential Naming**: Use STORY-XXX-PRB-001, PRB-002, etc. format
+5. **AgentTask Creation**: Generate properly formatted AgentTasks with resolved context
+6. **Sequential Naming**: Use STORY-XXX-AgentTask-001, AgentTask-002, etc. format
 
 ### Dynamic Specialist Creation
 **ALWAYS** create domain-specific specialists when technology expertise is needed:
 - Analyze technology stack and domain requirements
 - Create specialists like @React-Developer, @AWS-Engineer, @Security-Architect
 - No capability thresholds - create when expertise is beneficial
-- Document specialist creation rationale in PRB context
+- Document specialist creation rationale in AgentTask context
 
 ## Size Management Rules
-**CRITICAL**: Maintain PRB size limits through automatic breakdown:
-- **Single PRB**: ≤15 complexity points maximum
-- **Auto-Breakdown**: Stories >15 points split into multiple sequential PRBs
+**CRITICAL**: Maintain AgentTask size limits through automatic breakdown:
+- **Single AgentTask**: ≤15 complexity points maximum
+- **Auto-Breakdown**: Stories >15 points split into multiple sequential AgentTasks
 - **Logical Grouping**: Split by natural boundaries (frontend/backend, auth/data)
 - **Dependency Management**: Document execution order and prerequisites
 
 ## Coordination Principles
 - **Delegate, Don't Execute**: PM coordinates work but doesn't implement
-- **Context Provider**: Ensure all PRBs have complete embedded context
-- **Quality Guardian**: Validate all PRBs meet standards before assignment
+- **Context Provider**: Ensure all AgentTasks have complete embedded context
+- **Quality Guardian**: Validate all AgentTasks meet standards before assignment
 - **Communication Hub**: Interface between stakeholders and technical team
 
-## PRB Quality Requirements
-Every PRB created must include:
+## AgentTask Quality Requirements
+Every AgentTask created must include:
 - Complete context with actual values (no placeholders)
 - Absolute file paths and configuration values
 - Embedded memory search results and best practices
@@ -66,13 +66,13 @@ Every PRB created must include:
 ## Project Scope Awareness
 **SYSTEM NATURE**: MARKDOWN-BASED AI-AGENTIC SYSTEM
 - Work focuses on behavioral patterns, not code implementation
-- PRBs address framework enhancements and behavioral improvements
+- AgentTasks address framework enhancements and behavioral improvements
 - Coordinate AI/behavioral specialists for system improvements
 - Understand project is an instruction framework, not application code
 
 ## Success Metrics
-- All stories broken down into manageable PRBs ≤15 points
+- All stories broken down into manageable AgentTasks ≤15 points
 - Appropriate specialists assigned based on expertise needs
 - Clear coordination and dependency management
-- High-quality PRBs that execute successfully
+- High-quality AgentTasks that execute successfully
 - Effective stakeholder communication and expectation management

--- a/src/agents/qa-engineer.md
+++ b/src/agents/qa-engineer.md
@@ -35,7 +35,7 @@ As the **QA Engineer Agent**, you are responsible for quality assurance, test pl
 
 ## Specialization Capability
 
-You can specialize in ANY testing domain via PRB context:
+You can specialize in ANY testing domain via AgentTask context:
 - **Web Application Testing**: Frontend testing, cross-browser testing, responsive testing
 - **API Testing**: REST API, GraphQL, microservices, integration testing
 - **Mobile Testing**: iOS, Android, cross-platform, device compatibility
@@ -43,7 +43,7 @@ You can specialize in ANY testing domain via PRB context:
 - **Security Testing**: Penetration testing, vulnerability assessment, security compliance
 - **Automation Frameworks**: Test automation setup and maintenance
 
-When a PRB includes specialization context, fully embody that testing domain expertise.
+When a AgentTask includes specialization context, fully embody that testing domain expertise.
 
 ## Test Strategy & Planning
 

--- a/src/agents/requirements-engineer.md
+++ b/src/agents/requirements-engineer.md
@@ -36,7 +36,7 @@ As the **Requirements Engineer Agent**, you are responsible for requirements ana
 
 ## Specialization Capability
 
-You can specialize in ANY domain or industry via PRB context:
+You can specialize in ANY domain or industry via AgentTask context:
 - **Enterprise Software**: ERP, CRM, business process automation, workflow systems
 - **Financial Services**: Banking, payments, trading systems, regulatory compliance
 - **Healthcare**: HIPAA compliance, patient management, clinical workflows, medical devices
@@ -44,7 +44,7 @@ You can specialize in ANY domain or industry via PRB context:
 - **Government**: Regulatory compliance, public sector workflows, security requirements
 - **Mobile Applications**: User experience, device capabilities, offline functionality, app stores
 
-When a PRB includes specialization context, fully embody that domain expertise for requirements analysis.
+When a AgentTask includes specialization context, fully embody that domain expertise for requirements analysis.
 
 ## Requirements Analysis Framework
 

--- a/src/agents/security-engineer.md
+++ b/src/agents/security-engineer.md
@@ -35,7 +35,7 @@ As the **Security Engineer Agent**, you are responsible for security reviews, vu
 
 ## Specialization Capability
 
-You can specialize in ANY security domain via PRB context:
+You can specialize in ANY security domain via AgentTask context:
 - **Application Security**: SAST, DAST, secure coding, OWASP Top 10
 - **Cloud Security**: AWS Security, Azure Security, GCP Security, multi-cloud
 - **Network Security**: Firewalls, IDS/IPS, VPN, network segmentation
@@ -43,7 +43,7 @@ You can specialize in ANY security domain via PRB context:
 - **Compliance**: SOC2, GDPR, HIPAA, PCI-DSS, ISO 27001, NIST
 - **DevSecOps**: Security automation, pipeline integration, security as code
 
-When a PRB includes specialization context, fully embody that security domain expertise.
+When a AgentTask includes specialization context, fully embody that security domain expertise.
 
 ## Security Focus Areas
 

--- a/src/agents/system-engineer.md
+++ b/src/agents/system-engineer.md
@@ -35,7 +35,7 @@ As the **System Engineer Agent**, you are responsible for infrastructure, system
 
 ## Specialization Capability
 
-You can specialize in ANY infrastructure domain via PRB context:
+You can specialize in ANY infrastructure domain via AgentTask context:
 - **Cloud Platforms**: AWS, Azure, GCP, multi-cloud architectures
 - **Container Orchestration**: Kubernetes, Docker Swarm, container runtime
 - **Virtualization**: VMware, Hyper-V, KVM, virtual infrastructure
@@ -43,7 +43,7 @@ You can specialize in ANY infrastructure domain via PRB context:
 - **Storage Systems**: SAN, NAS, distributed storage, backup systems
 - **Operating Systems**: Linux, Windows, Unix system administration
 
-When a PRB includes specialization context, fully embody that infrastructure expertise.
+When a AgentTask includes specialization context, fully embody that infrastructure expertise.
 
 ## Technology Focus Areas
 

--- a/src/agents/user-role.md
+++ b/src/agents/user-role.md
@@ -27,7 +27,7 @@ As the **User Role Agent**, you are responsible for end-to-end testing, browser 
 
 ## Specialization Capability
 
-You can specialize in ANY testing domain via PRB context:
+You can specialize in ANY testing domain via AgentTask context:
 - **E-commerce Testing**: Shopping flows, payment processing, inventory management
 - **SaaS Application Testing**: User onboarding, feature adoption, subscription flows
 - **Mobile Web Testing**: Touch interactions, responsive design, offline functionality  
@@ -35,7 +35,7 @@ You can specialize in ANY testing domain via PRB context:
 - **Accessibility Testing**: WCAG compliance, screen reader testing, keyboard navigation
 - **Performance Testing**: Page load times, user interaction responsiveness
 
-When a PRB includes specialization context, fully embody that testing domain expertise.
+When a AgentTask includes specialization context, fully embody that testing domain expertise.
 
 ## Testing Implementation
 

--- a/src/agents/web-designer.md
+++ b/src/agents/web-designer.md
@@ -36,7 +36,7 @@ As the **Web Designer Agent**, you are responsible for UI/UX design, user experi
 
 ## Specialization Capability
 
-You can specialize in ANY design domain via PRB context:
+You can specialize in ANY design domain via AgentTask context:
 - **Web Applications**: SaaS platforms, admin dashboards, e-commerce, content management
 - **Mobile Design**: iOS, Android, responsive web, progressive web apps
 - **Design Systems**: Atomic design, component libraries, design tokens
@@ -44,7 +44,7 @@ You can specialize in ANY design domain via PRB context:
 - **Industry-Specific**: Healthcare, fintech, education, enterprise, consumer apps
 - **Emerging Technologies**: AR/VR interfaces, voice UI, IoT interfaces, AI/ML interfaces
 
-When a PRB includes specialization context, fully embody that design domain expertise.
+When a AgentTask includes specialization context, fully embody that design domain expertise.
 
 ## Design Process Framework
 

--- a/src/agenttask-templates/mega-agenttask-template.yaml
+++ b/src/agenttask-templates/mega-agenttask-template.yaml
@@ -258,9 +258,9 @@ mcp_operations:
 # Execution Strategy
 execution_strategy: |
   1. Create epic branch for system-wide coordination
-  2. Execute Phase 1 Large PRBs with validation gates
-  3. Execute Phase 2 Large PRBs building on Phase 1
-  4. Execute Integration Large PRBs for system unification
+  2. Execute Phase 1 Large AgentTasks with validation gates
+  3. Execute Phase 2 Large AgentTasks building on Phase 1
+  4. Execute Integration Large AgentTasks for system unification
   5. Comprehensive system testing and validation
   6. Documentation overhaul and migration guide creation
   7. Staged rollout with rollback capability
@@ -269,9 +269,9 @@ execution_strategy: |
 execution_checklist: |
   ☐ Epic branch created for system coordination (MANDATORY - validation enforced)
   ☐ Epic decomposition completed into phases (MANDATORY - no direct execution)
-  ☐ Phase 1 Large PRBs executed with validation (MANDATORY - phased approach)
-  ☐ Phase 2 Large PRBs executed building on Phase 1 (MANDATORY - dependency validation)
-  ☐ Integration Large PRBs executed for system unification (MANDATORY - coordination)
+  ☐ Phase 1 Large AgentTasks executed with validation (MANDATORY - phased approach)
+  ☐ Phase 2 Large AgentTasks executed building on Phase 1 (MANDATORY - dependency validation)
+  ☐ Integration Large AgentTasks executed for system unification (MANDATORY - coordination)
   ☐ Comprehensive system testing completed (MANDATORY - system validation)
   ☐ Documentation completely updated with migration guide (MANDATORY - no "No documentation needed")
   ☐ Architectural board review completed (MANDATORY - no "Review not required")

--- a/src/behaviors/shared-patterns/README.md
+++ b/src/behaviors/shared-patterns/README.md
@@ -11,16 +11,16 @@
 
 ### learning-patterns.md
 **Used by:** learning-team-automation, agenttask-creation-system, role-management
-**Purpose:** PRB learning capture, pattern detection, memory-first approach
-**Key:** AgentTask execution generates learnings, patterns applied in future PRBs
+**Purpose:** AgentTask learning capture, pattern detection, memory-first approach
+**Key:** AgentTask execution generates learnings, patterns applied in future AgentTasks
 
 ### memory-operations.md  
 **Used by:** learning-team-automation, memory commands (store/search/load)
-**Purpose:** Topic-based memory storage, pruning, PRB embedding
+**Purpose:** Topic-based memory storage, pruning, AgentTask embedding
 **Key:** memory/[topic]/, newest first, auto-prune at 5KB
 
 ### autonomy-patterns.md
-**Used by:** config-loader, role-management, prb behaviors
+**Used by:** config-loader, role-management, agenttask behaviors
 **Purpose:** L1/L2/L3 autonomy levels and enforcement
 **Key:** L1=manual, L2=guided, L3=autonomous
 

--- a/src/behaviors/shared-patterns/autonomy-patterns.md
+++ b/src/behaviors/shared-patterns/autonomy-patterns.md
@@ -23,8 +23,8 @@
 
 **L3 Continuous Work Pattern:**
 - **Discover Tasks:** Find PLANNED/IN_PROGRESS tasks, uncommitted changes, memory improvement opportunities
-- **Generate PRB:** Create appropriate PRB for discovered work
-- **Execute Work:** Complete the work using PRB framework
+- **Generate AgentTask:** Create appropriate AgentTask for discovered work
+- **Execute Work:** Complete the work using AgentTask framework
 - **Learn from Results:** Capture learnings and patterns
 - **Continue to Next:** Repeat cycle with next available work
 

--- a/src/behaviors/shared-patterns/continuation-work-patterns.md
+++ b/src/behaviors/shared-patterns/continuation-work-patterns.md
@@ -1,6 +1,6 @@
 # Continuation Work Patterns
 
-**MANDATORY:** Work that follows from previous work ALWAYS requires PRBs
+**MANDATORY:** Work that follows from previous work ALWAYS requires AgentTasks
 
 ## Core Principle
 
@@ -12,27 +12,27 @@ Its complexity CANNOT be predetermined because it depends on results.
 ### Category 1: Validation After Changes
 **TRIGGER:** Any code/config change completion
 **CONTINUATION:** Testing, linting, type checking, build verification
-**PRB REQUIRED:** ALWAYS - results unpredictable
+**AgentTask REQUIRED:** ALWAYS - results unpredictable
 
 ### Category 2: Fixes After Failures
 **TRIGGER:** Any validation/test failure
 **CONTINUATION:** Error analysis, bug fixes, corrections
-**PRB REQUIRED:** ALWAYS - fix complexity unknown
+**AgentTask REQUIRED:** ALWAYS - fix complexity unknown
 
 ### Category 3: Re-validation After Fixes  
 **TRIGGER:** Any fix completion
 **CONTINUATION:** Re-running tests, verification
-**PRB REQUIRED:** ALWAYS - fix effectiveness unknown
+**AgentTask REQUIRED:** ALWAYS - fix effectiveness unknown
 
 ### Category 4: Build After Validation
 **TRIGGER:** Successful validation
 **CONTINUATION:** Build, compilation, bundling
-**PRB REQUIRED:** ALWAYS - build issues possible
+**AgentTask REQUIRED:** ALWAYS - build issues possible
 
 ### Category 5: Deployment After Build
 **TRIGGER:** Successful build
 **CONTINUATION:** Deploy, release, publish
-**PRB REQUIRED:** ALWAYS - deployment complexity varies
+**AgentTask REQUIRED:** ALWAYS - deployment complexity varies
 
 ## Integration Rules
 
@@ -42,9 +42,9 @@ Its complexity CANNOT be predetermined because it depends on results.
 - Bypasses context evaluation
 - ALWAYS triggers AgentTask generation
 
-### With PRB Auto-Trigger
+### With AgentTask Auto-Trigger
 - Detect AgentTask completion → Check for continuation patterns
-- Match pattern → Generate continuation PRB
+- Match pattern → Generate continuation AgentTask
 - No pattern → Normal flow
 
 ## Common Continuation Chains
@@ -57,10 +57,10 @@ Its complexity CANNOT be predetermined because it depends on results.
 ## Blocking Patterns
 
 **NEVER ALLOW** main scope to execute:
-- "Let me test this" → Requires validation PRB
+- "Let me test this" → Requires validation AgentTask
 - "Let me fix this" → Requires fix AgentTask  
-- "Let me check if it works" → Requires validation PRB
-- "Let me build it" → Requires build PRB
+- "Let me check if it works" → Requires validation AgentTask
+- "Let me build it" → Requires build AgentTask
 
 ## Memory Storage
 

--- a/src/behaviors/shared-patterns/learning-patterns.md
+++ b/src/behaviors/shared-patterns/learning-patterns.md
@@ -12,7 +12,7 @@
 **Entry Format:** Date header, context, problem, solution, code examples
 **Topics:** Organized by domain (authentication, implementation, performance, etc.)
 
-### PRB Learning Logic
+### AgentTask Learning Logic
 **Learning Capture:** Pattern stored from successful AgentTask execution
 **Learning Application:** Memory patterns successfully applied in AgentTask context
 **Learning Reference:** Existing patterns referenced during AgentTask generation
@@ -30,12 +30,12 @@
 1. Embed relevant learnings directly in AgentTask during generation
 2. No runtime memory lookups needed (all in AgentTask)
 3. Execute work with embedded learning context
-4. Store new patterns in version control (PRB retrospective)
+4. Store new patterns in version control (AgentTask retrospective)
 
 ### Learning Processing Pattern
-**Pattern Recognition:** Identify successful patterns during AgentTask execution → Store learning entity with pattern details → Reference in future PRB contexts
+**Pattern Recognition:** Identify successful patterns during AgentTask execution → Store learning entity with pattern details → Reference in future AgentTask contexts
 
-**Learning Creation Process:** Store learning with pattern type, PRB context, observations about what/why/how, and application guidance
+**Learning Creation Process:** Store learning with pattern type, AgentTask context, observations about what/why/how, and application guidance
 
 ### Recovery Strategies
 **Auto-Recoverable:**
@@ -53,8 +53,8 @@
 ## Integration Patterns
 
 ### Memory Operations
-Memory embedding and storage are handled during PRB lifecycle:
-- **Embedding**: Relevant learnings copied into PRB context during generation
+Memory embedding and storage are handled during AgentTask lifecycle:
+- **Embedding**: Relevant learnings copied into AgentTask context during generation
 - **No Search**: All needed learnings are embedded, no runtime lookups
 - **Storage**: New learnings stored in version-controlled memory/
 - **Learning Capture**: Automatic during AgentTask completion
@@ -62,7 +62,7 @@ Memory embedding and storage are handled during PRB lifecycle:
 - **Details**: See memory-operations.md for version-controlled patterns
 
 ### Learning Application
-**PRB-Embedded Process:** PRB already contains relevant learnings → No search needed during execution → Work with embedded context → Store new learnings post-execution
+**AgentTask-Embedded Process:** AgentTask already contains relevant learnings → No search needed during execution → Work with embedded context → Store new learnings post-execution
 
 ### Issue Recovery
 **Recovery Decision:** Determine if issue is auto-recoverable → If yes: execute recovery strategy → If no: create fix task and continue other work

--- a/src/behaviors/shared-patterns/non-blocking-task-patterns.md
+++ b/src/behaviors/shared-patterns/non-blocking-task-patterns.md
@@ -6,21 +6,21 @@
 
 **Task Tool Invocation Pattern:**
 - **Agent Type**: Use general-purpose subagent for AgentTask execution
-- **Description**: Include specific PRB identifier for tracking
-- **Context**: Provide complete PRB context for autonomous execution
+- **Description**: Include specific AgentTask identifier for tracking
+- **Context**: Provide complete AgentTask context for autonomous execution
 - **Background Mode**: Enable background execution for parallel processing
 
 ## Execution Mode Decision
 
 | Condition | Mode | run_in_background |
 |-----------|------|------------------|
-| L3 + Independent PRBs + Capacity available | Non-blocking | true |
-| L1/L2 + Dependent PRBs + Critical ops | Blocking | false |
+| L3 + Independent AgentTasks + Capacity available | Non-blocking | true |
+| L1/L2 + Dependent AgentTasks + Critical ops | Blocking | false |
 
 ## Agent Management
 
 **Registry Pattern:**
-- Store: handle, prb_id, start_time, status
+- Store: handle, agenttask_id, start_time, status
 - Track: Periodic status checks (2-5 min intervals)
 - Lifecycle: Launch → Monitor → Complete → Cleanup
 - Capacity: Respect max_parallel setting, queue when full
@@ -44,7 +44,7 @@
 |------------|--------|----------|
 | Timeout | Terminate, log, retry | Manual review if repeated |
 | Failure | Capture context, auto-retry | Manual after retry limit |
-| Resource exhaustion | Queue PRB, reduce capacity | Resume when available |
+| Resource exhaustion | Queue AgentTask, reduce capacity | Resume when available |
 
 ## Integration
 

--- a/src/behaviors/shared-patterns/template-enforcement.md
+++ b/src/behaviors/shared-patterns/template-enforcement.md
@@ -12,7 +12,7 @@
 - `large-agenttask-template.yaml` (16-30 points)
 - `mega-agenttask-template.yaml` (30+ points)
 
-**BLOCKED:** AgentTask creation without templates, unresolved placeholders, runtime config lookups, manual PRB structures
+**BLOCKED:** AgentTask creation without templates, unresolved placeholders, runtime config lookups, manual AgentTask structures
 
 ### Placeholder Resolution
 **COMMON PLACEHOLDERS:**
@@ -30,7 +30,7 @@
 
 ## Integration Requirements
 
-### With PRB Creation System
+### With AgentTask Creation System
 - Block non-template AgentTask creation
 - Enforce placeholder resolution before creation
 - Validate template completeness
@@ -41,7 +41,7 @@
 - NO manual creation allowed
 
 ### With Execution System
-- PRBs execute with embedded configuration only
+- AgentTasks execute with embedded configuration only
 - Self-contained execution context
 - All settings pre-resolved and embedded
 

--- a/src/commands/icc-init-system.md
+++ b/src/commands/icc-init-system.md
@@ -34,7 +34,7 @@ and prepares the virtual team for work. Can be run by any role or automatically 
 Loading all behavioral patterns from installation/behaviors/:
   ✓ config-loader.md - Configuration hierarchy management
   ✓ directory-structure.md - Project structure enforcement
-  ✓ learning-team-automation.md - PRB learning and pattern capture
+  ✓ learning-team-automation.md - AgentTask learning and pattern capture
   ✓ naming-numbering-system.md - Work item naming and numbering standards  
   ✓ agenttask-auto-trigger.md - Automatic AgentTask generation
   ✓ agenttask-creation-system.md - AgentTask creation rules and validation
@@ -45,15 +45,15 @@ Loading all behavioral patterns from installation/behaviors/:
   ✓ shared-patterns/ - Common behavioral patterns (25 loaded)
 Behavioral pattern validation: ✅ All patterns successfully loaded and validated
 
-### 📋 RELOADING PRB TEMPLATES
+### 📋 RELOADING AGENTTASK TEMPLATES
 Loading all templates from template hierarchy:
 **Primary Templates:**
-  ✓ nano-prb-template.yaml - Trivial changes (0-2 points)
-  ✓ tiny-prb-template.yaml - Simple single-file (3-5 points)
-  ✓ medium-prb-template.yaml - Multi-file features (6-15 points)
-  ✓ large-prb-template.yaml - Complex coordination (16-30 points)
-  ✓ mega-prb-template.yaml - System-wide changes (30+ points)
-PRB template system: ✅ All templates validated with placeholder resolution capability
+  ✓ nano-agenttask-template.yaml - Trivial changes (0-2 points)
+  ✓ tiny-agenttask-template.yaml - Simple single-file (3-5 points)
+  ✓ medium-agenttask-template.yaml - Multi-file features (6-15 points)
+  ✓ large-agenttask-template.yaml - Complex coordination (16-30 points)
+  ✓ mega-agenttask-template.yaml - System-wide changes (30+ points)
+AgentTask template system: ✅ All templates validated with placeholder resolution capability
 
 ### 🎯 PROJECT SCOPE CONFIRMATION
 **Current Project Context:**
@@ -76,12 +76,12 @@ PRB template system: ✅ All templates validated with placeholder resolution cap
 6. **Read Autonomy Level**: Load autonomy_level from CLAUDE.md, create if missing
 7. **Initialize Memory System**: Bootstrap file-based memory system and search capabilities
 8. **Load Role Definitions**: Initialize 14 core roles and dynamic specialist capabilities
-9. **Activate PRB System**: Enable PRB-driven execution system with template validation
+9. **Activate AgentTask System**: Enable AgentTask-driven execution system with template validation
 10. **Initialize Workflow Settings**: Create default workflow configuration if missing from CLAUDE.md
 
 ### Phase 3: System Integration & Validation
 11. **Initialize Progress Reporting**: Activate clean completion tracking
-12. **Setup Learning System**: Enable PRB learning and pattern capture
+12. **Setup Learning System**: Enable AgentTask learning and pattern capture
 13. **Configure Tools**: Initialize Context7, GitHub CLI, Brave Search with fallbacks
 14. **Apply Autonomy Level**: Set L1/L2/L3 mode based on loaded/provided configuration
 15. **Persist Autonomy Changes**: Write autonomy_level changes back to CLAUDE.md for session preservation

--- a/src/commands/icc-search-memory.md
+++ b/src/commands/icc-search-memory.md
@@ -1,6 +1,6 @@
 # /icc-search-memory
 
-**Purpose:** Search version-controlled memory for embedding into PRBs
+**Purpose:** Search version-controlled memory for embedding into AgentTasks
 
 **Usage:** `/icc-search-memory [query]`
 
@@ -66,8 +66,8 @@ Found 3 relevant memories:
 - Tag search: "tag:authentication"
 
 ## Integration
-- Used during PRB generation to find relevant memories
-- Memories are embedded directly into PRBs
+- Used during AgentTask generation to find relevant memories
+- Memories are embedded directly into AgentTasks
 - Manual search for exploration
 - No runtime searches needed during execution
 - Auto-prunes large files during search (maintains 5-10 recent entries)

--- a/src/commands/init-system-validation.md
+++ b/src/commands/init-system-validation.md
@@ -12,12 +12,12 @@
 - ✅ Memory system operational with file access
 - ✅ Role definitions loaded (14 core + dynamic specialists)
 
-### PRB & Workflow Systems  
-- ✅ PRB system active with template validation
+### AgentTask & Workflow Systems  
+- ✅ AgentTask system active with template validation
 - ✅ Workflow settings initialized from CLAUDE.md
 - ✅ Template hierarchy operational
 - ✅ Placeholder resolution capability confirmed
-- ✅ PRB creation and execution patterns loaded
+- ✅ AgentTask creation and execution patterns loaded
 - ✅ Sequential thinking integration active
 
 ### Behavioral & Enforcement Systems
@@ -43,12 +43,12 @@
 **System Component Errors:**
 - **CONFIG_LOAD_FAILED**: "❌ Error: Failed to load configuration hierarchy. Check installation/config.md and project CLAUDE.md"
 - **BEHAVIORAL_PATTERN_LOAD_FAILED**: "❌ Critical: Behavioral patterns failed to load. Check installation/behaviors/ directory"
-- **TEMPLATE_VALIDATION_FAILED**: "❌ Error: PRB templates failed validation. Check template syntax and structure"
+- **TEMPLATE_VALIDATION_FAILED**: "❌ Error: AgentTask templates failed validation. Check template syntax and structure"
 - **MEMORY_BOOTSTRAP_FAILED**: "⚠️ Warning: Memory system bootstrap failed. Creating minimal fallback structure"
 - **ROLE_DEFINITION_FAILED**: "❌ Error: Role definitions failed to load. Check installation/roles/specialists.md"
 
 **Recovery & Validation Errors:**
-- **PRB_SYSTEM_VALIDATION_FAILED**: "❌ Critical: PRB system failed comprehensive validation. System not operational"
+- **AGENTTASK_SYSTEM_VALIDATION_FAILED**: "❌ Critical: AgentTask system failed comprehensive validation. System not operational"
 - **WORKFLOW_SETTINGS_CORRUPTED**: "⚠️ Warning: Workflow settings corrupted in CLAUDE.md. Recreating with defaults"
 - **AUTONOMY_PERSISTENCE_FAILED**: "⚠️ Warning: Cannot persist autonomy changes to CLAUDE.md. Using session-only settings"
 - **COMPREHENSIVE_VALIDATION_FAILED**: "❌ Critical: System failed comprehensive health check. Manual intervention required"

--- a/src/commands/workflow-settings-initialization.md
+++ b/src/commands/workflow-settings-initialization.md
@@ -1,12 +1,12 @@
 # Workflow Settings Initialization
 
-**MANDATORY:** Default workflow settings creation and management for PRB execution.
+**MANDATORY:** Default workflow settings creation and management for AgentTask execution.
 
 ## Workflow Settings Initialization
 
 When initializing workflow settings:
 - Checks if workflow_settings exists in CLAUDE.md
-- If missing, creates default workflow configuration for all PRB sizes
+- If missing, creates default workflow configuration for all AgentTask sizes
 - Workflow settings control version bumping, changelog requirements, PR creation, and merge strategies
 
 ## Default Configuration
@@ -19,7 +19,7 @@ When initializing workflow settings:
 - **mega**: Major version bump, changelog + PR + coordination + breaking change assessment, feature branch
 
 **Application:**
-- Settings are automatically applied during PRB template resolution
+- Settings are automatically applied during AgentTask template resolution
 - Can be customized per-project by editing CLAUDE.md workflow_settings section
 
 ## Memory System Details
@@ -31,7 +31,7 @@ When initializing memory system:
 - Creates memory/domain/ for domain knowledge and best practices
 - Creates memory/index.md for quick memory lookup
 - All memories are version-controlled (not in .gitignore)
-- Memories are embedded directly into PRBs during generation
+- Memories are embedded directly into AgentTasks during generation
 
 ## Autonomy Levels
 

--- a/src/modes/virtual-team.md
+++ b/src/modes/virtual-team.md
@@ -1,4 +1,4 @@
-# Virtual Team [PRB-DRIVEN]
+# Virtual Team [AGENTTASK-DRIVEN]
 
 ## Core Roles
 @../roles/specialists.md
@@ -37,31 +37,31 @@
 ## Advanced Features
 @../behaviors/template-resolution.md
 
-**CORE:** 14 roles+unlimited • 21 behaviors • @-notation • PRB-driven execution
+**CORE:** 14 roles+unlimited • 21 behaviors • @-notation • AgentTask-driven execution
 
 ## STARTUP
 
-1. Load CLAUDE.md → Config → Memory → Roles → PRBs
-2. Ready for work requests and PRB generation
+1. Load CLAUDE.md → Config → Memory → Roles → AgentTasks
+2. Ready for work requests and AgentTask generation
 
 ## PRINCIPLES
 
-**P1:** Work requests trigger PRB generation
+**P1:** Work requests trigger AgentTask generation
 **P2:** @-notation activates specialist roles
-**P3:** Complexity analysis selects PRB template
-**P4:** Direct execution from PRB context
+**P3:** Complexity analysis selects AgentTask template
+**P4:** Direct execution from AgentTask context
 **P5:** Knowledge capture after execution
 
 ## ROLE ACTIVATION
 
 **@Role:** Task tool creates subagents for ALL @Role mentions
 **Dynamic Specialists:** Created for specialized domains (@React-Developer, @AWS-Engineer)
-**Execution:** Always through PRBs with Task tool invocation
+**Execution:** Always through AgentTasks with Task tool invocation
 
 ## OPERATION
 
-**Work Detection:** Request → Complexity analysis → PRB generation
-**PRB Types:** Nano → Tiny → Medium → Large → Mega
+**Work Detection:** Request → Complexity analysis → AgentTask generation
+**AgentTask Types:** Nano → Tiny → Medium → Large → Mega
 **Execution:** Single-pass with complete context
-**Validation:** Built into PRB structure
+**Validation:** Built into AgentTask structure
 **Learning:** Auto-capture successes and failures


### PR DESCRIPTION
## Summary

This PR fixes all PRB references in the installation source files to use AgentTask terminology, ensuring consistency between documentation and the actual installation components.

### Background

While the documentation cleanup addressed the docs/ directory, the source files in src/ that get installed to ~/.claude/ still contained PRB references. This created inconsistency between the documented system and the installed system.

### Changes Made

**Major File Updates:**
- `src/modes/virtual-team.md`: Updated header from "PRB-DRIVEN" to "AGENTTASK-DRIVEN"
- All agent files (`src/agents/*.md`): Updated specialization context references
- `src/agenttask-templates/`: Updated template execution references
- `src/behaviors/`: Updated all behavioral pattern files
- `src/commands/`: Updated command definitions and help text
- `Makefile`: Fixed test to check for agenttask-templates instead of prb-templates

**Terminology Replacements:**
- `PRB` → `AgentTask` throughout all files
- `prb-templates` → `agenttask-templates`
- `PRB context` → `AgentTask context` 
- `PRB execution` → `AgentTask execution`
- `.prb.yaml` → `.agenttask.yaml`

### Test Results

✅ All tests pass - system functionality maintained
✅ Installation verification updated and working
✅ Terminology now consistent across entire codebase

### Impact

- **Zero Breaking Changes**: Functionality remains identical
- **Improved Consistency**: Documentation and installation now use same terminology
- **Future Maintenance**: Eliminates confusion between PRB and AgentTask references

This completes the terminology standardization effort across the entire intelligent-claude-code system.

🤖 Generated with Claude Code